### PR TITLE
[KW-490] feat: QR 스캔 관리자 로그인 API 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,7 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate  } from 'react-router-dom';
+
+import PrivateRoute from './contexts/PrivateRoute';
+
 import LoginSwitcher from './components/switcher/LoginSwitcher';
 import BuildingSelectPage from './pages/BuildingSelectPage';
 import ZoneSelectPage from './pages/ZoneSelectPage';
@@ -8,8 +11,10 @@ function App() {
     <Router>
       <Routes>
         <Route path="/login" element={<LoginSwitcher />} />
+        <Route element={<PrivateRoute />}>
         <Route path="/building/select" element={<BuildingSelectPage />} />
         <Route path="/zone/select" element={<ZoneSelectPage />} />
+        </Route>
       </Routes>
     </Router>
   );

--- a/src/apis/loginApi.ts
+++ b/src/apis/loginApi.ts
@@ -1,0 +1,45 @@
+import axios, { AxiosError } from "axios";
+import axiosWithAuthorization from "../contexts/axiosWithAuthorization";
+
+// 관리자 로그인
+interface LoginRequest {
+    username: string;
+    password: string;
+}
+
+const axiosWithoutAuth = axios.create({
+    baseURL: import.meta.env.VITE_PUBLIC_KEYWE_SERVER_URI,
+    withCredentials: true,
+});
+
+export const adminLogin = async (payload: LoginRequest) => {
+    try {
+        const res = await axiosWithoutAuth.post('/auth/login', payload);
+
+        const token = res.data.data?.accessToken;
+    if (!token) {
+        throw new Error('로그인 응답에 accessToken이 포함되어 있지 않습니다.');
+    }
+
+    localStorage.setItem('accessToken', token);
+
+      return res.data.data;
+  } catch (error) {
+      const err = error as AxiosError<{ data?: { message?: string } }>;
+      const message = err.response?.data?.data?.message ?? "관리자 로그인에 실패했습니다.";
+      throw new Error(message);
+  }
+};
+
+// 관리자 로그아웃
+export const adminLogout = async () => {
+    try {
+      const res = await axiosWithAuthorization.post(`/auth/logout`);
+      localStorage.removeItem('accessToken');
+      return res.data.data;
+    } catch (error) {
+      const err = error as AxiosError<{ data?: { message?: string } }>;
+      const message = err.response?.data?.data?.message ?? "관리자 로그아웃에 실패했습니다.";
+      throw new Error(message);
+    }
+}

--- a/src/components/building/BuildingLoginCard.tsx
+++ b/src/components/building/BuildingLoginCard.tsx
@@ -1,27 +1,43 @@
 import './css/BuildingLoginCard.css';
 import { useState } from 'react';
+import { useNavigate } from "react-router-dom";
+import { adminLogin } from '../../apis/loginApi';
 
 interface Props {
   onSwitch: () => void;
   isExiting: boolean;
   direction: 'up' | 'down';
+  onLogin: () => void;
 }
 
-const BuildingLoginCard: React.FC<Props> = ({ onSwitch: _, isExiting, direction }) => {
-  const [id, setId] = useState('');
+const BuildingLoginCard: React.FC<Props> = ({ onSwitch: _, isExiting, direction, onLogin }) => {
+  const [adminId, setAdminId] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  const handleLogin = async () => {
+    try {
+      const response = await adminLogin({
+        username: adminId,
+        password: password,
+      });
+    const token = response.accessToken;
+      if (token) {
+        localStorage.setItem("accessToken", token);
+        onLogin();
+        navigate("/building/select");
+      } else {
+        setError("로그인 실패: 엑세스 토큰이 없음");
+      }
+    } catch (error: any) {
+      setError(error.message); 
+    }
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-
-    if (id !== 'building' || password !== '1234') {
-      setError('일치하는 정보가 존재하지 않습니다.\n입력 내용을 다시 확인해주세요.');
-    } else {
-      setError('');
-      console.log('건물 로그인 성공!');
-      // api연결
-    }
+    handleLogin();
   };
 
   return (
@@ -42,8 +58,8 @@ const BuildingLoginCard: React.FC<Props> = ({ onSwitch: _, isExiting, direction 
           <input
             type="text"
             placeholder="관리자 ID"
-            value={id}
-            onChange={(e) => setId(e.target.value)}
+            value={adminId}
+            onChange={(e) => setAdminId(e.target.value)}
           />
           <input
             type="password"

--- a/src/components/zone/ZoneLoginCard.tsx
+++ b/src/components/zone/ZoneLoginCard.tsx
@@ -1,27 +1,43 @@
 import './css/ZoneLoginCard.css';
 import { useState } from 'react';
+import { useNavigate } from "react-router-dom";
+import { adminLogin } from '../../apis/loginApi';
 
 interface Props {
   onSwitch: () => void;
   isExiting: boolean;
   direction: 'up' | 'down';
+  onLogin: () => void;
 }
 
-const ZoneLoginCard: React.FC<Props> = ({ onSwitch: _, isExiting, direction }) => {
-  const [id, setId] = useState('');
+const ZoneLoginCard: React.FC<Props> = ({ onSwitch: _, isExiting, direction, onLogin }) => {
+  const [adminId, setAdminId] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  const handleLogin = async () => {
+    try {
+      const response = await adminLogin({
+        username: adminId,
+        password: password,
+      });
+    const token = response.accessToken;
+      if (token) {
+        localStorage.setItem("accessToken", token);
+        onLogin();
+        navigate("/zone/select");
+      } else {
+        setError("로그인 실패: 엑세스 토큰이 없음");
+      }
+    } catch (error: any) {
+      setError(error.message); 
+    }
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-
-    if (id !== 'zone' || password !== '5678') {
-      setError('일치하는 정보가 존재하지 않습니다.\n입력 내용을 다시 확인해주세요.');
-    } else {
-      setError('');
-      console.log('구역 로그인 성공!');
-      //  api연결
-    }
+    handleLogin();
   };
 
   return (
@@ -41,8 +57,8 @@ const ZoneLoginCard: React.FC<Props> = ({ onSwitch: _, isExiting, direction }) =
           <input
             type="text"
             placeholder="관리자 ID"
-            value={id}
-            onChange={(e) => setId(e.target.value)}
+            value={adminId}
+            onChange={(e) => setAdminId(e.target.value)}
           />
           <input
             type="password"

--- a/src/contexts/PrivateRoute.tsx
+++ b/src/contexts/PrivateRoute.tsx
@@ -1,0 +1,8 @@
+import { Navigate, Outlet } from 'react-router-dom';
+
+const PrivateRoute = () => {
+  const isLoggedIn = !!localStorage.getItem('accessToken');
+  return isLoggedIn ? <Outlet /> : <Navigate to="/admin/login" replace />;
+};
+
+export default PrivateRoute;

--- a/src/contexts/axiosWithAuthorization.tsx
+++ b/src/contexts/axiosWithAuthorization.tsx
@@ -1,0 +1,77 @@
+import axios, { AxiosError, type AxiosInstance, type AxiosRequestConfig, type AxiosResponse } from 'axios';
+
+const getAccessToken = (): string | null => {
+  return localStorage.getItem("accessToken");
+};
+
+const axiosWithAuthorization: AxiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_PUBLIC_KEYWE_SERVER_URI,
+  withCredentials: true,
+});
+
+const axiosWithoutAuth: AxiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_PUBLIC_KEYWE_SERVER_URI,
+  withCredentials: true,
+});
+
+// 요청 인터셉터
+axiosWithAuthorization.interceptors.request.use((config) => {
+  const token = getAccessToken();
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// 응답 인터셉터
+axiosWithAuthorization.interceptors.response.use(
+  (response: AxiosResponse) => response,
+  async (error: AxiosError) => {
+    const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean };
+
+    console.log("401 발생한 요청 경로:", originalRequest.url);
+
+    if (error.response?.status === 401 && !originalRequest._retry && originalRequest.url !== "/auth/reissue") {
+      originalRequest._retry = true;
+      console.warn("401 에러 발생하여 엑세스 토큰 재발급 시도");
+
+      try {
+        const accessToken = getAccessToken(); 
+
+        const res = await axiosWithoutAuth.post(
+          "/auth/reissue",
+          {},
+          {
+            withCredentials: true,
+            headers: {
+              Authorization: `Bearer ${accessToken}`, 
+            },
+          }
+        );
+
+        const newAccessToken = res.headers["authorization"]?.replace("Bearer ", "");
+
+        if (newAccessToken) {
+          localStorage.setItem("accessToken", newAccessToken);
+
+          originalRequest.headers = originalRequest.headers || {};
+          originalRequest.headers['Authorization'] = `Bearer ${newAccessToken}`;
+          console.info("엑세스 토큰 재발급 성공 및 재요청 수행");
+        
+          return axiosWithAuthorization.request(originalRequest);
+        }
+        // 엑세스 토큰을 받지 못했을 경우
+        return Promise.reject(new Error("새로운 accessToken을 받지 못했습니다."));
+      } catch (refreshError) {
+        console.error("엑세스 토큰 재발급 실패:", refreshError);
+        localStorage.clear(); 
+        window.location.href = "/admin/login";
+        return Promise.reject(refreshError);
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+export default axiosWithAuthorization;

--- a/src/pages/BuildingLoginPage.tsx
+++ b/src/pages/BuildingLoginPage.tsx
@@ -27,6 +27,10 @@ const BuildingLoginPage: React.FC<Props> = ({ onSwitch, isExiting, direction }) 
     }
   }, [isExiting, onSwitch]);
 
+  const handleLogin = () => {
+    console.log('로그인 성공');
+  };
+
   return (
     <div className="building-login-page-description-wrapper">
       <div
@@ -45,6 +49,7 @@ const BuildingLoginPage: React.FC<Props> = ({ onSwitch, isExiting, direction }) 
           onSwitch={onSwitch}
           isExiting={isExiting}
           direction={direction}
+          onLogin={handleLogin}
         />
       </div>
     </div>

--- a/src/pages/ZoneLoginPage.tsx
+++ b/src/pages/ZoneLoginPage.tsx
@@ -27,6 +27,10 @@ const ZoneLoginPage: React.FC<Props> = ({ onSwitch, isExiting, direction }) => {
     }
   }, [isExiting, onSwitch]);
 
+  const handleLogin = () => {
+    console.log('로그인 성공');
+  };
+
   return (
     <div className="zone-login-page-description-wrapper">
       <div
@@ -45,6 +49,7 @@ const ZoneLoginPage: React.FC<Props> = ({ onSwitch, isExiting, direction }) => {
           onSwitch={onSwitch}
           isExiting={isExiting}
           direction={direction}
+          onLogin={handleLogin}
         />
       </div>
     </div>


### PR DESCRIPTION
## 🔷 관련 Jira Ticket ID

[KW-490]

---
## 📌 작업 내용 및 특이사항

- 건물/구역 로그인 API 연결하였습니다.
- axiosWithAuthorization 인스턴스에 요청/응답 인터셉터를 설정하여 응답에서 401 에러가 발생하면 '/auth/reissue' 엔드포인트로 리프레시 토큰을 포함한 요청을 전송하고 새 엑세스 토큰을 발급받은 후 원요청을 재시도하도록 구현하였습니다.

---
## 📚 참고사항

- 로그인 요청은 adminLogin 함수에서 axiosWithoutAuth를 통해 수행합니다. 
- 로그아웃 요청은 adminLogout 함수에서 axiosWithAuthorization를 통해 처리할 예정입니다.


[KW-490]: https://teamdoubleo.atlassian.net/browse/KW-490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ